### PR TITLE
sepolicy: Switch to SYSTEM_EXT_{PUBLIC,PRIVATE}_SEPOLICY_DIRS

### DIFF
--- a/common/sepolicy.mk
+++ b/common/sepolicy.mk
@@ -27,12 +27,12 @@ SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/halcyon/sepolicy/common/system
 
 ifneq ($(TARGET_HAL_POWER_RW_INPUT_DEVICE), true)
-BOARD_PLAT_PRIVATE_SEPOLICY_DIR += \
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/halcyon/sepolicy/common/dynamic_extra
 endif
 
 else
-BOARD_VENDOR_SEPOLICY_DIRS += \
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/halcyon/sepolicy/common/dynamic \
     device/halcyon/sepolicy/common/dynamic_extra \
     device/halcyon/sepolicy/common/vendor

--- a/exynos/sepolicy.mk
+++ b/exynos/sepolicy.mk
@@ -17,7 +17,7 @@ SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/halcyon/sepolicy/exynos/dynamic \
     device/halcyon/sepolicy/exynos/system
 else
-BOARD_VENDOR_SEPOLICY_DIRS += \
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/halcyon/sepolicy/exynos/dynamic \
     device/halcyon/sepolicy/exynos/vendor
 endif

--- a/qcom/sepolicy.mk
+++ b/qcom/sepolicy.mk
@@ -17,13 +17,13 @@ SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/halcyon/sepolicy/qcom/dynamic \
     device/halcyon/sepolicy/qcom/system
 else
-BOARD_VENDOR_SEPOLICY_DIRS += \
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/halcyon/sepolicy/qcom/dynamic \
     device/halcyon/sepolicy/qcom/vendor
 endif
 
 ifneq ($(filter msm8960 msm8226 msm8610 msm8974 apq8084 msm8909 msm8916 msm8952 msm8992 msm8994,$(TARGET_BOARD_PLATFORM)),)
-BOARD_VENDOR_SEPOLICY_DIRS += \
+SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += \
     device/halcyon/sepolicy/qcom/legacy-vendor
 endif
 


### PR DESCRIPTION
Fixes:
warning: BOARD_PLAT_PRIVATE_SEPOLICY_DIR has been deprecated.
    Use SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS instead.
warning: BOARD_PLAT_PUBLIC_SEPOLICY_DIR has been deprecated.
    Use SYSTEM_EXT_PUBLIC_SEPOLICY_DIRS instead.
Change-Id: I752602079de8ff4c5370fe3ec861b8746838d878